### PR TITLE
Create folder if open file failed

### DIFF
--- a/src/gitbook.js
+++ b/src/gitbook.js
@@ -26,8 +26,9 @@ class Gitbook {
       fsPromises.access(fileName)
         .then(() => {
           this.showDoc(fileName)
-        }).catch(() => {
-          return fsPromises.writeFile(fileName, '')
+        }).catch(async () => {
+          await fsPromises.mkdir(path.dirname(fileName), { recursive: true })
+          await fsPromises.writeFile(fileName, '')
         }).then(() => {
           this.showDoc(fileName)
         }).catch(() => {


### PR DESCRIPTION
If open file failed, create folder for the target file before creating file.

This modification can help when the folder for the target file does not exist yet.
The API `fsPromises.mkdir` will success even if the folder does exist.